### PR TITLE
source伝搬の問題とclose watch pluginの実装

### DIFF
--- a/pybotters_wrapper/binance/plugins/binancecoinm/__init__.py
+++ b/pybotters_wrapper/binance/plugins/binancecoinm/__init__.py
@@ -1,1 +1,5 @@
-from .binningbook import BinningBook
+from .close_watcher import CloseWatcher
+
+__all__ = (
+    "CloseWatcher"
+)

--- a/pybotters_wrapper/binance/plugins/binancecoinm/close_watcher.py
+++ b/pybotters_wrapper/binance/plugins/binancecoinm/close_watcher.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+
+from ....core.store import DataStoreWrapper, OrderItem
+from ....plugins._base import DataStorePlugin
+
+
+class CloseWatcher(DataStorePlugin):
+    def __init__(self, store: "DataStoreWrapper"):
+        # ExecutionDataStoreを監視
+        super(CloseWatcher, self).__init__(store.order)
+        self._order_id = None
+        self._item = None
+        self._done = None
+        self._status = None
+        self._event = asyncio.Event()
+
+    def set(self, order_id: str) -> CloseWatcher:
+        """監視対象の注文IDをセット"""
+        if self._order_id is not None:
+            raise RuntimeError(
+                "CancelWatcher must not be 'reused', create a new instance instead."
+            )
+        self._order_id = order_id
+        self._event.set()
+        return self
+
+    async def _on_watch(self, store: "DataStore", operation: str, source: dict, data: dict):
+    # async def _on_watch(self, d: OrderItem, op: str):
+        """open orderが約定したかチェック
+        約定後のstatus FILLED or CANCEL の状態を更新
+        """
+        if not self._event.is_set():
+            # order_idがsetされるまで待機
+            # 注文が即約定した時にsocket messageがresのresponseより早く到達するケースがあるので、
+            # order_idがセットされるまでメッセージをここで待機させておく
+            await self._event.wait()
+        if data["id"] == self._order_id and operation == 'update':
+            self._status = 'OPEN'
+        if data["id"] == self._order_id and operation == 'delete':  # なくなったらexecuted or cancelと判断
+            if (source['info']['source']['X'] == 'FILLED'):
+                self._done = True
+                self._item = data
+                self._status = 'FILLED'
+            else:  # cancel
+                self._done = True
+                self._item = data
+                self._status = 'CANCEL'
+
+    @property
+    def status(self):
+        return self._status
+
+    def _on_watch_is_stop(self, store: "DataStore", operation: str, source: dict, data: dict) -> bool:
+        """監視終了判定"""
+        return self._done
+
+    def done(self) -> bool:
+        return self._done
+
+    def result(self) -> OrderItem:
+        return self._item
+
+    async def wait(self):
+        return await self._watch_task
+
+    @property
+    def order_id(self) -> str:
+        return self._order_id

--- a/pybotters_wrapper/binance/plugins/binancecoinm_test/__init__.py
+++ b/pybotters_wrapper/binance/plugins/binancecoinm_test/__init__.py
@@ -1,0 +1,5 @@
+from .close_watcher import CloseWatcher
+
+__all__ = (
+    "CloseWatcher"
+)

--- a/pybotters_wrapper/binance/plugins/binancecoinm_test/close_watcher.py
+++ b/pybotters_wrapper/binance/plugins/binancecoinm_test/close_watcher.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+
+from ....core.store import DataStoreWrapper, OrderItem
+from ....plugins._base import DataStorePlugin
+
+
+class CloseWatcher(DataStorePlugin):
+    def __init__(self, store: "DataStoreWrapper"):
+        # ExecutionDataStoreを監視
+        super(CloseWatcher, self).__init__(store.order)
+        self._order_id = None
+        self._item = None
+        self._done = None
+        self._status = None
+        self._event = asyncio.Event()
+
+    def set(self, order_id: str) -> CloseWatcher:
+        """監視対象の注文IDをセット"""
+        if self._order_id is not None:
+            raise RuntimeError(
+                "CancelWatcher must not be 'reused', create a new instance instead."
+            )
+        self._order_id = order_id
+        self._event.set()
+        return self
+
+    async def _on_watch(self, store: "DataStore", operation: str, source: dict, data: dict):
+    # async def _on_watch(self, d: OrderItem, op: str):
+        """open orderが約定したかチェック
+        約定後のstatus FILLED or CANCEL の状態を更新
+        """
+        if not self._event.is_set():
+            # order_idがsetされるまで待機
+            # 注文が即約定した時にsocket messageがresのresponseより早く到達するケースがあるので、
+            # order_idがセットされるまでメッセージをここで待機させておく
+            await self._event.wait()
+        if data["id"] == self._order_id and operation == 'update':
+            self._status = 'OPEN'
+        if data["id"] == self._order_id and operation == 'delete':  # なくなったらexecuted or cancelと判断
+            if (source['info']['source']['X'] == 'FILLED'):
+                self._done = True
+                self._item = data
+                self._status = 'FILLED'
+            else:  # cancel
+                self._done = True
+                self._item = data
+                self._status = 'CANCEL'
+
+    @property
+    def status(self):
+        return self._status
+
+    def _on_watch_is_stop(self, store: "DataStore", operation: str, source: dict, data: dict) -> bool:
+        """監視終了判定"""
+        return self._done
+
+    def done(self) -> bool:
+        return self._done
+
+    def result(self) -> OrderItem:
+        return self._item
+
+    async def wait(self):
+        return await self._watch_task
+
+    @property
+    def order_id(self) -> str:
+        return self._order_id

--- a/pybotters_wrapper/binance/plugins/binanceusdsm/__init__.py
+++ b/pybotters_wrapper/binance/plugins/binanceusdsm/__init__.py
@@ -1,0 +1,5 @@
+from .close_watcher import CloseWatcher
+
+__all__ = (
+    "CloseWatcher"
+)

--- a/pybotters_wrapper/binance/plugins/binanceusdsm/close_watcher.py
+++ b/pybotters_wrapper/binance/plugins/binanceusdsm/close_watcher.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+
+from ....core.store import DataStoreWrapper, OrderItem
+from ....plugins._base import DataStorePlugin
+
+
+class CloseWatcher(DataStorePlugin):
+    def __init__(self, store: "DataStoreWrapper"):
+        # ExecutionDataStoreを監視
+        super(CloseWatcher, self).__init__(store.order)
+        self._order_id = None
+        self._item = None
+        self._done = None
+        self._status = None
+        self._event = asyncio.Event()
+
+    def set(self, order_id: str) -> CloseWatcher:
+        """監視対象の注文IDをセット"""
+        if self._order_id is not None:
+            raise RuntimeError(
+                "CancelWatcher must not be 'reused', create a new instance instead."
+            )
+        self._order_id = order_id
+        self._event.set()
+        return self
+
+    async def _on_watch(self, store: "DataStore", operation: str, source: dict, data: dict):
+    # async def _on_watch(self, d: OrderItem, op: str):
+        """open orderが約定したかチェック
+        約定後のstatus FILLED or CANCEL の状態を更新
+        """
+        if not self._event.is_set():
+            # order_idがsetされるまで待機
+            # 注文が即約定した時にsocket messageがresのresponseより早く到達するケースがあるので、
+            # order_idがセットされるまでメッセージをここで待機させておく
+            await self._event.wait()
+        if data["id"] == self._order_id and operation == 'update':
+            self._status = 'OPEN'
+        if data["id"] == self._order_id and operation == 'delete':  # なくなったらexecuted or cancelと判断
+            if (source['info']['source']['X'] == 'FILLED'):
+                self._done = True
+                self._item = data
+                self._status = 'FILLED'
+            else:  # cancel
+                self._done = True
+                self._item = data
+                self._status = 'CANCEL'
+
+    @property
+    def status(self):
+        return self._status
+
+    def _on_watch_is_stop(self, store: "DataStore", operation: str, source: dict, data: dict) -> bool:
+        """監視終了判定"""
+        return self._done
+
+    def done(self) -> bool:
+        return self._done
+
+    def result(self) -> OrderItem:
+        return self._item
+
+    async def wait(self):
+        return await self._watch_task
+
+    @property
+    def order_id(self) -> str:
+        return self._order_id

--- a/pybotters_wrapper/binance/plugins/binanceusdsm_test/__init__.py
+++ b/pybotters_wrapper/binance/plugins/binanceusdsm_test/__init__.py
@@ -1,0 +1,5 @@
+from .close_watcher import CloseWatcher
+
+__all__ = (
+    "CloseWatcher"
+)

--- a/pybotters_wrapper/binance/plugins/binanceusdsm_test/close_watcher.py
+++ b/pybotters_wrapper/binance/plugins/binanceusdsm_test/close_watcher.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+
+from ....core.store import DataStoreWrapper, OrderItem
+from ....plugins._base import DataStorePlugin
+
+
+class CloseWatcher(DataStorePlugin):
+    def __init__(self, store: "DataStoreWrapper"):
+        # ExecutionDataStoreを監視
+        super(CloseWatcher, self).__init__(store.order)
+        self._order_id = None
+        self._item = None
+        self._done = None
+        self._status = None
+        self._event = asyncio.Event()
+
+    def set(self, order_id: str) -> CloseWatcher:
+        """監視対象の注文IDをセット"""
+        if self._order_id is not None:
+            raise RuntimeError(
+                "CancelWatcher must not be 'reused', create a new instance instead."
+            )
+        self._order_id = order_id
+        self._event.set()
+        return self
+
+    async def _on_watch(self, store: "DataStore", operation: str, source: dict, data: dict):
+    # async def _on_watch(self, d: OrderItem, op: str):
+        """open orderが約定したかチェック
+        約定後のstatus FILLED or CANCEL の状態を更新
+        """
+        if not self._event.is_set():
+            # order_idがsetされるまで待機
+            # 注文が即約定した時にsocket messageがresのresponseより早く到達するケースがあるので、
+            # order_idがセットされるまでメッセージをここで待機させておく
+            await self._event.wait()
+        if data["id"] == self._order_id and operation == 'update':
+            self._status = 'OPEN'
+        if data["id"] == self._order_id and operation == 'delete':  # なくなったらexecuted or cancelと判断
+            if (source['info']['source']['X'] == 'FILLED'):
+                self._done = True
+                self._item = data
+                self._status = 'FILLED'
+            else:  # cancel
+                self._done = True
+                self._item = data
+                self._status = 'CANCEL'
+
+    @property
+    def status(self):
+        return self._status
+
+    def _on_watch_is_stop(self, store: "DataStore", operation: str, source: dict, data: dict) -> bool:
+        """監視終了判定"""
+        return self._done
+
+    def done(self) -> bool:
+        return self._done
+
+    def result(self) -> OrderItem:
+        return self._item
+
+    async def wait(self):
+        return await self._watch_task
+
+    @property
+    def order_id(self) -> str:
+        return self._order_id

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -490,7 +490,7 @@ class NormalizedDataStore(DataStore):
         return data
 
     def _make_item(self, transformed_item: "Item", change: "StoreChange") -> "Item":
-        return {**transformed_item, "info": change.data}
+        return {**transformed_item, "info": {'data': change.data, 'source': change.source}}
 
     def _check_operation(self, op):
         if op not in self._AVAILABLE_OPERATIONS:

--- a/sample/misc/plugin_close_watch_binanceusdm_test.py
+++ b/sample/misc/plugin_close_watch_binanceusdm_test.py
@@ -1,0 +1,70 @@
+import asyncio
+from argparse import ArgumentParser
+import pybotters_wrapper as pbw
+from pybotters_wrapper.binance.plugins.binanceusdsm_test import CloseWatcher
+
+
+# 約定するギリギリの価格に注文をopen. 1か2をテストできる。
+# 1. 約定を確認 status: OPEN -> FILLED  (その後market orderでpositionを解消)
+# 2. 取引ページからキャンセル status: OPEN -> CANCEL
+
+async def get_price(store):
+    while True:
+        await store.orderbook.wait()
+        asks, bids = store.orderbook.sorted().values()
+        if len(asks) != 0:
+            break
+    return asks[0]['price']
+
+
+async def main(args):
+    # logger
+    logdir = pbw.utils.init_logdir(args.exchange, args.symbol)
+    pbw.utils.init_logger(f"{logdir}/log.txt", rotation="10MB", retention=3)
+    pbw.utils.log_command_args(logdir, args)
+
+    async with pbw.create_client(apis=args.api) as client:
+        api = pbw.create_api(args.exchange, client, verbose=True)
+        store = pbw.create_store(args.exchange)
+
+        # ストアの初期化
+        await store.initialize([], client=client)
+        # wsでsubscribe開始
+        await store.subscribe(["order", "orderbook"], symbol=args.symbol).connect(client, auto_reconnect=True)
+        # close監視をスケジューリング
+        close_watcher = CloseWatcher(store)
+        # ギリギリ約定しない買い注文をエントリー
+        price = await get_price(store) - 1
+        side = 'BUY'
+        size = args.lot
+        resp_order = await api.limit_order(args.symbol, side, price, size)
+        close_watcher.set(resp_order.order_id)
+        # await api.cancel_order(args.symbol, resp_order.order_id)
+        while not close_watcher.done():
+            await asyncio.sleep(1)
+            print(close_watcher.status)
+        print(close_watcher.status)
+        print(close_watcher.result())
+
+        if close_watcher.status == 'FILLED':
+            await asyncio.sleep(5)
+            print('EXIT order')
+            side = 'SELL'
+            await api.market_order(args.symbol, side, size)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Simple Market Making Bot")
+    parser.add_argument("--api", help="apiキーが入ったJSONファイル", default="apis.json", )
+    parser.add_argument("--exchange", default="binanceusdsm_test",
+        choices=["binanceusdsm_test", "binancecoinm_test", "binanceusdsm", "binancecoinm", "bitflyer", "bybitinverse",
+                 "bybitusdt", "kucoinfutures"])
+    parser.add_argument("--symbol", default="BTCUSDT")
+    parser.add_argument("--lot", help="注文ロット", default=0.01, type=float)
+
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(main(args))
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
#65 の問題の修正
この変更でon_watchの 
```source['info']['source']```でsourceの情報にアクセスできるようになる。

もっといい方法があればrejectしてもらっても大丈夫です。