### PR TITLE
NormalizedDataStoreのinfoにsource情報を追加

### DIFF
--- a/pybotters_wrapper/binance/store.py
+++ b/pybotters_wrapper/binance/store.py
@@ -110,7 +110,7 @@ class BinanceExecutionStore(ExecutionStore):
                     float(item["l"]),
                     pd.to_datetime(item["T"], unit="ms", utc=True),
                 )
-                self._insert([{**item, "info": msg}])
+                self._insert([{**item, "info": {"data": msg, "source": None}}])
 
 
 class BinancePositionStore(PositionStore):

--- a/pybotters_wrapper/bitflyer/store.py
+++ b/pybotters_wrapper/bitflyer/store.py
@@ -121,7 +121,7 @@ class bitFlyerPositionStore(PositionStore):
         for i in self._store.find():
             item = {
                 **self._normalize(change.store, change.operation, change.source, i),
-                "info": i,
+                "info": {"data": i, "source": change.source},
             }
             items.append(item)
         self._insert(items)

--- a/pybotters_wrapper/bybit/store.py
+++ b/pybotters_wrapper/bybit/store.py
@@ -68,7 +68,10 @@ class BybitOrderStore(OrderStore):
             if topic == "order":
                 for item in data:
                     normalized_item = self._normalize(None, None, None, item)
-                    normalized_item = {**normalized_item, "info": item}
+                    normalized_item = {
+                        **normalized_item,
+                        "info": {"data": item, "source": None},
+                    }
                     if item["order_status"] in ("Created", "New", "PartiallyFilled"):
                         self._update([normalized_item])
                     else:
@@ -77,7 +80,10 @@ class BybitOrderStore(OrderStore):
             elif topic == "stop_order":
                 for item in data:
                     normalized_item = self._normalize(None, None, None, item)
-                    normalized_item = {**normalized_item, "info": item}
+                    normalized_item = {
+                        **normalized_item,
+                        "info": {"data": item, "source": None},
+                    }
                     if item["order_status"] in ("Active", "Untriggered"):
                         self._update([normalized_item])
                     else:

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -495,10 +495,10 @@ class NormalizedDataStore(DataStore):
             "info": {"data": change.data, "source": change.source},
         }
 
-    def _check_operation(self, op):
-        if op not in self._AVAILABLE_OPERATIONS:
+    def _check_operation(self, operation: str):
+        if operation not in self._AVAILABLE_OPERATIONS:
             raise RuntimeError(
-                f"Unsupported operation '{op}' for {self.__class__.__name__}"
+                f"Unsupported operation '{operation}' for {self.__class__.__name__}"
             )
 
     def _itemize(self, *args, **kwargs):

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -490,7 +490,10 @@ class NormalizedDataStore(DataStore):
         return data
 
     def _make_item(self, transformed_item: "Item", change: "StoreChange") -> "Item":
-        return {**transformed_item, "info": change.data}
+        return {
+            **transformed_item,
+            "info": {"data": change.data, "source": change.source},
+        }
 
     def _check_operation(self, op):
         if op not in self._AVAILABLE_OPERATIONS:

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -490,6 +490,8 @@ class NormalizedDataStore(DataStore):
         return data
 
     def _make_item(self, transformed_item: "Item", change: "StoreChange") -> "Item":
+        # ストアに格納するアイテムとしてはchange.sourceは不要かもしれないが、watchした際に元のitemの
+        # sourceをたどりたい場合がありうるので付帯させる
         return {
             **transformed_item,
             "info": {"data": change.data, "source": change.source},


### PR DESCRIPTION
#65 

データストアのアイテムとしては sourceを格納する必要性は必ずしもないが、pluginのレベルにおいてはsourceにアクセスしたくなるケースがあるので付帯させる。

ただし、NormalizedDataStoreのwatchはあくまでもNormalizedDataStoreのCRUDロジックに依存しているでの、infoを参照する際は注意が必要（例えば特定のケースはスキップする、などあり得るかもしれない）。
