### PR TITLE
kucoinのexecution storeの挿入ロジックを修正

### DIFF
--- a/pybotters_wrapper/kucoin/store.py
+++ b/pybotters_wrapper/kucoin/store.py
@@ -89,14 +89,14 @@ class KuCoinOrderStore(OrderStore):
 
 class KuCoinExecutionStore(ExecutionStore):
     def _get_operation(self, change: "StoreChange") -> str | None:
-        if change.data["type"] == "filled":
+        if change.data["type"] == "match":
             return "_insert"
 
     def _normalize(
         self, store: "DataStore", operation: str, source: dict, data: dict
     ) -> "ExecutionItem":
         try:
-            price = float(data["price"])
+            price = float(data["matchPrice"])
         except ValueError:
             price = 0
 
@@ -105,7 +105,7 @@ class KuCoinExecutionStore(ExecutionStore):
             data["symbol"],
             data["side"].upper(),
             price,
-            float(data["size"]),
+            float(data["matchSize"]),
             pd.to_datetime(int(data["ts"]), unit="ns", utc=True),
         )
 


### PR DESCRIPTION

（修正前）全数約定したタイミングでの配信しか挿入されなかった（部分約定が挿入されない）。
（修正後）全約定が挿入される
