### PR TITLE
initializationのリファクタ

### DIFF
--- a/pybotters_wrapper/binance/store.py
+++ b/pybotters_wrapper/binance/store.py
@@ -207,17 +207,17 @@ class BinanceSpotDataStoreWrapper(
         self,
         client: "pybotters.Client",
         method: str,
-        endpoint: str,
+        url: str,
         params_or_data: dict | None = None,
         **kwargs,
     ):
         from .api import BinanceSpotAPI
 
         kwargs = kwargs or {}
-        if URL(endpoint).path in BinanceSpotAPI._PUBLIC_ENDPOINTS:
+        if URL(url).path in BinanceSpotAPI._PUBLIC_ENDPOINTS:
             kwargs["auth"] = None
         return await super()._initialize_request(
-            client, method, endpoint, params_or_data, **kwargs
+            client, method, url, params_or_data, **kwargs
         )
 
 

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -396,7 +396,7 @@ class DataStoreWrapper(Generic[T], ExchangeMixin, LoggingMixin):
             raise RuntimeError(f"Initialization failed: {result.url} {data}")
 
     async def _initialize_with_validation(self, *aws: list[Awaitable]):
-        tasks = [asyncio.create_task(aw) for aw in aws if aw is not None]
+        tasks = [asyncio.create_task(aw) for aw in aws]
         try:
             await self._store.initialize(*tasks)
         except AttributeError:

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -98,6 +98,39 @@ class DataStoreWrapper(Generic[T], ExchangeMixin, LoggingMixin):
 
         return self
 
+    async def _initialize_by_config(self, client: "pybotters", name: str, **kwargs):
+        await self._initialize_with_validation(
+            self._initialize_request_from_conf(client, name, **kwargs)
+        )
+        return self
+
+    async def initialize_token(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "token", **kwargs)
+
+    async def initialize_public_token(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "public_token", **kwargs)
+
+    async def initialize_private_token(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "private_token", **kwargs)
+
+    async def initialize_ticker(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "ticker", **kwargs)
+
+    async def initialize_trades(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "trades", **kwargs)
+
+    async def initialize_orderbook(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "orderbook", **kwargs)
+
+    async def initialize_order(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "order", **kwargs)
+
+    async def initialize_execution(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "execution", **kwargs)
+
+    async def initialize_position(self, client: "pybotters.Client", **kwargs):
+        return await self._initialize_by_config(client, "position", **kwargs)
+
     def subscribe(
         self, channel: str | list[str] | list[tuple[str, dict]], **kwargs
     ) -> "DataStoreWrapper":

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -101,25 +101,6 @@ class DataStoreWrapper(Generic[T], ExchangeMixin, LoggingMixin):
 
         return self
 
-    async def _initialize_with_validation(self, *request_tasks: list[asyncio.Task]):
-        try:
-            await self._store.initialize(*request_tasks)
-        except AttributeError:
-            # initializeはDataStoreManagerのメソッドではなく、各実装クラスレベルでのメソッド
-            # bitbankDataStoreなど実装がない
-            pass
-        finally:
-            # APIレスポンスが成功していたかチェック
-            for task in request_tasks:
-                result: ClientResponse = task.result()
-                if result.status != 200:
-                    try:
-                        data = await result.json()
-                    except Exception:
-                        data = None
-                    raise RuntimeError(f"Initialization failed: {result.url} {data}")
-
-
     def subscribe(
         self, channel: str | list[str] | list[tuple[str, dict]], **kwargs
     ) -> "DataStoreWrapper":

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -381,8 +381,7 @@ class DataStoreWrapper(Generic[T], ExchangeMixin, LoggingMixin):
                 raise RuntimeError(
                     f"Missing required parameters for initializing "
                     f"'{name}' of {self.__class__.__name__}: "
-                    f"{params} (HINT: store.initialize([('{name}', "
-                    f"{str({p: '...' for p in params})}), ...))"
+                    f"{conf.params} are required."
                 )
 
         return await self._initialize_request(client, conf.method, conf.url, params)

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -94,9 +94,6 @@ class DataStoreWrapper(Generic[T], ExchangeMixin, LoggingMixin):
                     self._initialize_request_from_conf(client, a_or_n[0], **a_or_n[1])
                 )
 
-        # null confを除外
-        awaitables = [aws for aws in awaitables if aws is not None]
-
         await self._initialize_with_validation(*awaitables)
 
         return self
@@ -367,7 +364,7 @@ class DataStoreWrapper(Generic[T], ExchangeMixin, LoggingMixin):
             raise RuntimeError(f"Initialization failed: {result.url} {data}")
 
     async def _initialize_with_validation(self, *aws: list[Awaitable]):
-        tasks = [asyncio.create_task(aw) for aw in aws]
+        tasks = [asyncio.create_task(aw) for aw in aws if aw is not None]
         try:
             await self._store.initialize(*tasks)
         except AttributeError:

--- a/pybotters_wrapper/core/store.py
+++ b/pybotters_wrapper/core/store.py
@@ -83,7 +83,6 @@ class DataStoreWrapper(Generic[T], ExchangeMixin, LoggingMixin):
                 awaitables.append(a_or_n)
 
             elif isinstance(a_or_n, str):
-                _check_client()
                 awaitables.append(self._initialize_request_from_conf(client, a_or_n))
             elif (
                 isinstance(a_or_n, tuple)
@@ -91,7 +90,6 @@ class DataStoreWrapper(Generic[T], ExchangeMixin, LoggingMixin):
                 and isinstance(a_or_n[0], str)
                 and isinstance(a_or_n[1], dict)
             ):
-                _check_client()
                 awaitables.append(
                     self._initialize_request_from_conf(client, a_or_n[0], **a_or_n[1])
                 )

--- a/sample/misc/datastore_wrapper_initialize.py
+++ b/sample/misc/datastore_wrapper_initialize.py
@@ -1,0 +1,43 @@
+import asyncio
+import pybotters_wrapper as pbw
+
+
+async def main():
+
+    async with pbw.create_client() as client:
+        store = pbw.create_binanceusdsm_store()
+        api = pbw.create_binanceusdsm_api(client)
+
+        symbol = "BTCUSDT"
+
+        # １個ずつ初期化
+        # await store.initialize_position(client)
+        # await store.initialize_orderbook(client, symbol=symbol)
+
+        # 並列で初期化
+        await asyncio.gather(
+            store.initialize_position(client),
+            store.initialize_orderbook(client, symbol=symbol)
+        )
+
+        # 1メソッドで初期化
+        # await store.initialize([
+        #     "position",
+        #     ("orderbook", {"symbol": symbol})
+        # ], client)
+
+        # 任意のエンドポイントを初期化
+        await store.initialize([
+            api.get("/fapi/v1/klines?symbol=BTCUSDT&interval=1m")
+        ], client)
+
+        await asyncio.sleep(1)
+
+        print(store.position.find())
+        print(store.orderbook.find()[:5])
+        print(store.store.kline.find()[:5])
+
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 import pytest
+import pytest_asyncio
 
 from unittest import TestCase
+
+
+import pybotters
+import pybotters_wrapper as pbw
 
 
 @pytest.fixture
@@ -8,3 +13,8 @@ def testcase() -> TestCase:
     testcase = TestCase()
     testcase.maxDiff = None
     return testcase
+
+
+@pytest_asyncio.fixture
+async def client() -> pybotters.Client:
+    return pbw.create_client()

--- a/tests/test_datastore_wrapper_initialize.py
+++ b/tests/test_datastore_wrapper_initialize.py
@@ -1,0 +1,57 @@
+import unittest
+
+import pybotters
+import pytest
+
+import pybotters_wrapper as pbw
+
+
+@pytest.mark.asyncio
+async def test_initialize(testcase: unittest.TestCase, client: pybotters.Client):
+    store = pbw.create_binancespot_store()
+    symbol = "BTCUSDT"
+    await store.initialize(
+        [
+            ("orderbook", {"symbol": symbol}),
+            client.get(
+                "https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=1m",
+                auth=None,
+            ),
+        ],
+        client,
+    )
+
+    if len(store.orderbook) == 0:
+        await store.orderbook.wait()
+    testcase.assertNotEqual(0, len(store.orderbook))
+    testcase.assertNotEqual(0, len(store.store.kline))
+
+
+@pytest.mark.asyncio
+async def test_initialize_by_conf(
+    testcase: unittest.TestCase, client: pybotters.Client
+):
+    store = pbw.create_binancespot_store()
+    symbol = "BTCUSDT"
+    await store.initialize_orderbook(client, symbol=symbol)
+    if len(store.orderbook) == 0:
+        await store.orderbook.wait()
+    testcase.assertNotEqual(0, len(store.orderbook))
+
+
+@pytest.mark.asyncio
+async def test_initialize_missing_parameter(
+    testcase: unittest.TestCase, client: pybotters.Client
+):
+    store = pbw.create_binancespot_store()
+    with pytest.raises(RuntimeError):
+        await store.initialize_orderbook(client)
+
+
+@pytest.mark.asyncio
+async def test_initialize_null_conf(
+    testcase: unittest.TestCase, client: pybotters.Client
+):
+    store = pbw.create_binancespot_store()
+    await store.initialize_ticker(client)  # ログを吐き出してスルー
+    testcase.assertEqual(0, len(store.ticker))


### PR DESCRIPTION
ちょっとスッキリした書き方をできるようにした。

Close #83 

```python
import asyncio
import pybotters_wrapper as pbw


async def main():

    async with pbw.create_client() as client:
        store = pbw.create_binanceusdsm_store()
        api = pbw.create_binanceusdsm_api(client)

        symbol = "BTCUSDT"

        # １個ずつ初期化
        await store.initialize_position(client)
        await store.initialize_orderbook(client, symbol=symbol)

        # 並列で初期化
        await asyncio.gather(
            store.initialize_position(client),
            store.initialize_orderbook(client, symbol=symbol)
        )

        # 1メソッドで初期化（従来のやり方）
        await store.initialize([
            "position",
            ("orderbook", {"symbol": symbol})
        ], client)

        # 任意のエンドポイントを初期化
        await store.initialize([
            api.get("/fapi/v1/klines?symbol=BTCUSDT&interval=1m")
        ], client)

        await asyncio.sleep(1)

        print(store.position.find())
        print(store.orderbook.find()[:5])
        print(store.store.kline.find()[:5])



if __name__ == "__main__":
    asyncio.run(main())

```