### PR TITLE
GMOCoinTradesStoreのキー重複を修正

### DIFF
--- a/pybotters_wrapper/gmocoin/store.py
+++ b/pybotters_wrapper/gmocoin/store.py
@@ -32,7 +32,7 @@ class GMOCoinTickerStore(TickerStore):
 class GMOCoinTradesStore(TradesStore):
     def _normalize(self, store: "DataStore", operation: str, source: dict, data: dict) -> "TradesItem":
         return self._itemize(
-            str(hash(str(data))),
+            str(uuid.uuid4()),
             data["symbol"].name,
             data["side"].name,
             float(data["price"]),

--- a/pybotters_wrapper/gmocoin/store.py
+++ b/pybotters_wrapper/gmocoin/store.py
@@ -32,7 +32,7 @@ class GMOCoinTickerStore(TickerStore):
 class GMOCoinTradesStore(TradesStore):
     def _normalize(self, store: "DataStore", operation: str, source: dict, data: dict) -> "TradesItem":
         return self._itemize(
-            hash(tuple(data)),
+            str(hash(str(data))),
             data["symbol"].name,
             data["side"].name,
             float(data["price"]),

--- a/pybotters_wrapper/gmocoin/store.py
+++ b/pybotters_wrapper/gmocoin/store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 
 import pandas as pd
 import pybotters


### PR DESCRIPTION
## 事象
GMOCoinTradesStoreへsymbol毎に約定履歴が1件しか保存されない。

## 原因
キー重複。現状GMOCoinTradesStore._normalize()はidに`hash(tuple(data))`を設定している。

https://github.com/ko0hi/pybotters-wrapper/blob/0b621a7194c10964e09ea08faf6251b45110cef2/pybotters_wrapper/gmocoin/store.py#L35

`tuple(data)`はdataのキーだけが返ってくるので、常に同じ値となりhash値が変わらない。
TradesStoreの_KEYSはid, symbolなので、キー重複が起こり最新の受信内容で上書きされる。

## 対応
hash化する際にdataのvalueを含める。

ついでに現状TradesItem.idがintになっているが、本来はstrなのでキャストするよう修正する。