### PR TITLE
gmocoinのOrderItem.typeをEnumからstrに修正

### DIFF
--- a/pybotters_wrapper/gmocoin/store.py
+++ b/pybotters_wrapper/gmocoin/store.py
@@ -57,7 +57,7 @@ class GMOCoinOrderStore(OrderStore):
             data["side"].name,
             float(data["price"]),
             float(data["size"]),
-            data["execution_type"],
+            data["execution_type"].name,
         )
 
 


### PR DESCRIPTION
## 事象

gmocoinのOrderItem.typeについて、str (ex. "LIMIT") が入るべきところEnum (ex. <ExecutionType.LIMIT: 2>) が入っている。

## 原因

OrderItem.typeのみEnumをそのままセットしているため。

## 対応

Enumからnameを取得してセットする。

## 修正前

```
{'id': '123456789', 'symbol': 'BTC_JPY', 'side': 'BUY', 'price': 2000000.0, 'size': 0.01, 'type': <ExecutionType.LIMIT: 2>, 'info': {'data': {'order_id': 123456789, 'symbol': <Symbol.BTC_JPY: 22>, 'settle_type': <SettleType.OPEN: 1>, 'execution_type': <ExecutionType.LIMIT: 2>, 'side': <OrderSide.BUY: 1>, 'order_status': <OrderStatus.ORDERED: 2>, 'cancel_type': <CancelType.NONE: 1>, 'order_timestamp': datetime.datetime(2023, 3, 18, 14, 46, 48, 927000), 'price': Decimal('2000000'), 'size': Decimal('0.01'), 'executed_size': Decimal('0'), 'losscut_price': Decimal('0'), 'time_in_force': 'FAS'}, 'source': None}}
```

## 修正後

```
{'id': '123456789', 'symbol': 'BTC_JPY', 'side': 'BUY', 'price': 2000000.0, 'size': 0.01, 'type': 'LIMIT', 'info': {'data': {'order_id': 123456789, 'symbol': <Symbol.BTC_JPY: 22>, 'settle_type': <SettleType.OPEN: 1>, 'execution_type': <ExecutionType.LIMIT: 2>, 'side': <OrderSide.BUY: 1>, 'order_status': <OrderStatus.ORDERED: 2>, 'cancel_type': <CancelType.NONE: 1>, 'order_timestamp': datetime.datetime(2023, 3, 18, 14, 55, 0, 521000), 'price': Decimal('2000000'), 'size': Decimal('0.01'), 'executed_size': Decimal('0'), 'losscut_price': Decimal('0'), 'time_in_force': 'FAS'}, 'source': None}}
```