### PR TITLE
bybit, kucoinのExecutionStoreに約定履歴が入らない件の修正

### DIFF
--- a/pybotters_wrapper/bybit/normalized_store_builder.py
+++ b/pybotters_wrapper/bybit/normalized_store_builder.py
@@ -84,7 +84,7 @@ class BybitNormalizedStoreBuilder(
                     d["trade_time"], utc=True
                 ),
             },
-            on_watch_get_operation=lambda change: "_insert",
+            on_watch_get_operation=lambda change: "insert",
         )
 
     def position(self) -> PositionStore:

--- a/pybotters_wrapper/kucoin/normalized_store_builder.py
+++ b/pybotters_wrapper/kucoin/normalized_store_builder.py
@@ -97,7 +97,7 @@ class KuCoinNormalizedStoreBuilder(NormalizedStoreBuilder[KuCoinDataStore]):
                     int(d["ts"]), unit="ns", utc=True
                 ),
             },
-            on_watch_get_operation=lambda change: "_insert"
+            on_watch_get_operation=lambda change: "insert"
             if change.data["type"] == "match"
             else None,
         )


### PR DESCRIPTION
bybit, kucoinのExecutionStoreについて、約定履歴が入らないようです。

確認したところそれぞれon_watch_get_operationを指定しており、"_insert"を返すようになっています。
従って以下の箇所でopに"_insert"が入り、op_fn = getattr(self, "_" + op) = "__insert" となります（_が一個余分に付いている）。
このため、self._insertが呼べていないことが原因のようです。

https://github.com/ko0hi/pybotters-wrapper/blob/d5a1d40c8dedca8366d43b5a298966809d7fda02/pybotters_wrapper/core/store/normalized_store.py#L157-L167

on_watch_get_operationは"insert"を返すのが正しいのでは思い、PRを送らせていただきました。