### PR TITLE
GMOCoinのTradeStore.idが一意になるよう修正

### DIFF
--- a/pybotters_wrapper/gmocoin/normalized_store_builder.py
+++ b/pybotters_wrapper/gmocoin/normalized_store_builder.py
@@ -28,7 +28,7 @@ class GMOCoinNormalizedStoreBuilder(NormalizedStoreBuilder[GMOCoinDataStore]):
         return TradesStore(
             self._store.trades,
             mapper={
-                "id": str(uuid.uuid4()),
+                "id": lambda store, o, s, d: str(uuid.uuid4()),
                 "symbol": lambda store, o, s, d: d["symbol"].name,
                 "side": lambda store, o, s, d: d["side"].name,
                 "price": lambda store, o, s, d: float(d["price"]),


### PR DESCRIPTION
## 事象

GMOCoinのTradeStoreについて、全てのデータに同じ`id`が入っており、約定履歴IDが重複している。

## 原因

mapperの`id`の定義が固定文字列`str(uuid.uuid4())`になっているため、`_normalize()`時に毎回uuidが生成されていないようです。

## 対応

Bitget, Phemexの実装に倣い、`id`の定義をcallbleに修正することで毎回`uuid4()`を呼び出すようにしました。

https://github.com/ko0hi/pybotters-wrapper/blob/2a35d64fc9816d9e0c434e78ed90cfbaed079079/pybotters_wrapper/bitget/normalized_store_builder.py#L32
https://github.com/ko0hi/pybotters-wrapper/blob/2a35d64fc9816d9e0c434e78ed90cfbaed079079/pybotters_wrapper/phemex/normalized_store_builder.py#L32